### PR TITLE
Add LDpred2 prs method

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -40,7 +40,7 @@ if (params.target_plink_dir) {
      }
     .groupTuple()
     //.set { target_plink_dir_ch }
-    .into { target_plink_dir_ch; target_plink_dir_ldpred_ch }
+    .into { target_plink_dir_ch; target_plink_dir_ldpred_ch; target_plink_dir_ldpred_gibbs_ch }
 }
 
 
@@ -367,6 +367,25 @@ if ( params.ldpred ) {
         --rs SNPID 1> ldpred_coord.log
         """
     }
+
+    process ldpred_gibbs {
+        
+        input:
+        each file(cf_file) from harmonised_coord_ch
+        tuple val(name), file("*") from target_plink_dir_ldpred_gibbs_ch
+        
+        output:
+        file("ldpred.weights*") into ldpred_weights_ch
+
+        script:
+        """
+        ldpred gibbs \
+        --cf ${cf_file} \
+        --ldr 150 \
+        --out ldpred.weights \
+        --ldf sampleA_chr1_filtered 1> ldpred.weights.log
+        """
+    }
 }
 
 
@@ -390,6 +409,8 @@ process additional_plots {
   plot_prs_vs_cov.R --input_cov ${cov} --input_prs ${prs} --input_metadata ${metadata}
   plot_prs_density.R --input_pheno ${pheno} --input_prs ${prs}
   """
+
+  
 
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -148,6 +148,9 @@ process {
     withName: 'ldpred_gibbs' {
     container = 'lifebitai/ldpred:latest'
   }
+      withName: 'ldpred_score' {
+    container = 'lifebitai/ldpred:latest'
+  }
 
   withLabel: high_memory {
     cpus = 16

--- a/nextflow.config
+++ b/nextflow.config
@@ -34,7 +34,11 @@ params {
   target_pheno      = false
   binary_trait      = true
 
-  // 4 - Phenotype metadata - necessary for determining which covariates to plot
+  // 4 - PRS method
+
+  ldpred = false
+
+  // 5 - Phenotype metadata - necessary for determining which covariates to plot
 
   pheno_metadata = "https://lifebit-featured-datasets.s3-eu-west-1.amazonaws.com/pipelines/prs/metadata_phenotypes_mapping_file.csv"
 
@@ -138,6 +142,9 @@ params {
 // Process parameters
 
 process {
+  withName: 'ldpred_coord' {
+    container = 'lifebitai/ldpred:latest'
+  }
 
   withLabel: high_memory {
     cpus = 16

--- a/nextflow.config
+++ b/nextflow.config
@@ -142,6 +142,9 @@ params {
 // Process parameters
 
 process {
+  withName: 'merge_plink' {
+    container = 'lifebitai/plink1:latest'
+  }
   withName: 'ldpred_coord' {
     container = 'lifebitai/ldpred:latest'
   }

--- a/nextflow.config
+++ b/nextflow.config
@@ -145,6 +145,9 @@ process {
   withName: 'ldpred_coord' {
     container = 'lifebitai/ldpred:latest'
   }
+    withName: 'ldpred_gibbs' {
+    container = 'lifebitai/ldpred:latest'
+  }
 
   withLabel: high_memory {
     cpus = 16


### PR DESCRIPTION
# This PR does the following:

It adds LDpred as an alternative method for calcularing PRS.

# Details of changes:
- Updated `main.nf` with additional processes to support LDpred, specifically `merge_plink`, `ldpred_coord`, `ldpred_gibbs` and `ldpred_score`. `merge_plink` combines per chr plink files into one set, `ldpred_coord` harmonises base and target cohorts, `ldpred gibbs` uses a Gibbs sampler to re-estimate effect estimates using LD information from a reference and `ldpred_score` calculates polygenic risk scores for the individuals in the target cohort. 

- Added `ldpred` flag in `nextflow.config` (false by default)

- Updated `nextflow.config` with corresponding Docker containers required for the aforementioned processes

# Testing

Successfully tested on an EC2 instance:
<img width="863" alt="Screenshot 2021-07-22 at 11 21 11" src="https://user-images.githubusercontent.com/33654687/126624773-2ba1efba-6add-4b78-ba51-fa6309331c87.png">



